### PR TITLE
Updating path to cirrus binary as its location changed in UE 4.27

### DIFF
--- a/Engine/Source/Programs/PixelStreaming/WebServers/SignallingWebServer/Start_Azure_SignallingServer.ps1
+++ b/Engine/Source/Programs/PixelStreaming/WebServers/SignallingWebServer/Start_Azure_SignallingServer.ps1
@@ -15,7 +15,17 @@ Write-Output "Public IP: $PublicIp"
 $peerConnectionOptions = "{ \""iceServers\"": [{\""urls\"": [\""stun:stun.l.google.com:19302\""]}] }"
 
 $ProcessExe = "node.exe"
-$Arguments = @("cirrus", "--peerConnectionOptions=""$peerConnectionOptions""", "--publicIp=$PublicIp")
+
+# defaults to UE 4.27 path where cirrus is 2 directories higher in the path tree
+$cirrusPath = "../../cirrus"
+
+$exists = Test-Path -Path $cirrusPath
+if(!$exists){
+    # fall back to pathing used for 4.26 and earlier
+    $cirrusPath = "cirrus"
+}
+
+$Arguments = @($cirrusPath, "--peerConnectionOptions=""$peerConnectionOptions""", "--publicIp=$PublicIp")
 
 # Add arguments passed to script to Arguments for executable
 $Arguments += $args


### PR DESCRIPTION
This PR updates the signal server start script for Azure, to address the issue reported in #8 . The script will now default to the new 4.27 location for `cirrus` but will fall back to the previous location if the new location does not exist.