### PR TITLE
Updating gitignore to not exclude folder name patterns found in library paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,6 @@ mono_crash.*
 [Dd]ebugPublic/
 [Rr]elease/
 [Rr]eleases/
-x64/
-x86/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 bld/


### PR DESCRIPTION
Simple update to the gitignore file, so that folders named x64 or x86 are not excluded from being tracked in the repository. This is important for consumers who fork this repository and add in necessary 3rd party libraries. Some libraries have folders that would be excluded by these rules and it breaks the deployed application. 